### PR TITLE
Fix column selection for non-interaction variables in report_missing

### DIFF
--- a/R/compute_metrics.R
+++ b/R/compute_metrics.R
@@ -127,6 +127,8 @@ report_missing <- function(seminr_model) {
     missing_proportion = numeric()
   )
   no_int_mmvars <- seminr_model$mmVariables[!grepl("\\*", seminr_model$mmVariables)]
+  # Check that all no_int_mmvars are present in raw data
+  no_int_mmvars <- intersect(no_int_mmvars, names(seminr_model$rawdata))
   # subset raw data for missing analysis
   data_subset <- seminr_model$rawdata[, no_int_mmvars]
   for (i in 1:ncol(data_subset)) {


### PR DESCRIPTION
Hello,

This filters non-interaction multimode variables to only those present in the raw data before attempting column selection, preventing an error ('undefined columns selected') when composite variable names don't match raw data columns in HOC models.