### PR TITLE
fix: bootstrap error-recovery with HOC and PLSc models

### DIFF
--- a/CLAUDE.ray-fix-hoc-bootstrap.md
+++ b/CLAUDE.ray-fix-hoc-bootstrap.md
@@ -1,0 +1,116 @@
+# Plan: Fix HOC Bootstrap (#299 and #205)
+
+**Branch**: `ray/fix-hoc-bootstrap`
+**Issues**: [#299](https://github.com/sem-in-r/seminr/issues/299) — bootstrap_model() errors when PLSc and HOC in model, [#205](https://github.com/sem-in-r/seminr/issues/205) — PLSc bootstrap errors with HOC
+
+## Issue Summary
+
+Both issues report that `bootstrap_model()` fails when the model contains both Higher-Order Constructs (HOC) and reflective constructs (triggering PLSc). The root cause is a miscalculated `length` variable in the bootstrap error-recovery code.
+
+## Root Cause Analysis
+
+### The `length` formula bug (`estimate_bootstrap.R:111`)
+
+```r
+length <- 3*nrow(seminr_model$path_coef)^2 + 2*nrow(seminr_model$outer_loadings)*ncol(seminr_model$outer_loadings)
+```
+
+This formula computes the expected size of the flattened bootstrap result vector. Each bootstrap iteration returns (lines 125-129):
+
+```r
+c(path_coef, outer_loadings, outer_weights, htmt, total_effects)
+```
+
+**Actual sizes:**
+| Component       | Size                                    |
+|-----------------|-----------------------------------------|
+| path_coef       | `nrow(path_coef) * ncol(path_coef)`     |
+| outer_loadings  | `nrow(loadings) * ncol(loadings)`       |
+| outer_weights   | `nrow(loadings) * ncol(loadings)`       |
+| HTMT            | `nrow(HTMT) * ncol(HTMT)`              |
+| total_effects   | `nrow(path_coef) * ncol(path_coef)`     |
+
+**Actual total** = `2 * nrow(path)^2 + 2 * nrow(load) * ncol(load) + nrow(HTMT) * ncol(HTMT)`
+
+**Formula assumes** = `3 * nrow(path)^2 + 2 * nrow(load) * ncol(load)`
+
+The formula assumes HTMT has the same dimensions as `path_coef`. This is wrong because:
+
+1. **HTMT excludes interaction constructs**: Interaction terms (e.g., `Image*Expectation`) appear in path_coef but not in HTMT (they're not in `mmMatrix`).
+2. **HOC models add extra constructs to HTMT**: The HTMT function's HOC branch (`evaluate_validity.R:51`) includes constructs from `first_stage_model$smMatrix`, making HTMT potentially larger or differently sized than `path_coef`.
+
+### Why it manifests as a crash
+
+The `length` variable is only used in the error handler (line 134) to create an NA vector when a bootstrap iteration fails:
+
+```r
+error = function(cond) { return(rep(NA, length)) }
+```
+
+When PLSc `solve()` fails on a bootstrap sample (common with HOC due to higher dimensionality), the NA vector is `length`-sized while successful iterations return the actual-sized vector. `parSapply` cannot combine columns of different lengths, causing the entire bootstrap to crash.
+
+### Concrete example with the existing HOC test model
+
+- path_coef: 5x5 = 25 elements
+- outer_loadings: 23x7 = 161 elements
+- outer_weights: 23x7 = 161 elements
+- HTMT: 7x7 = 49 elements (includes Image, Value from first-stage)
+- total_effects: 5x5 = 25 elements
+- **Actual total**: 421
+- **Formula `length`**: 397
+- **Mismatch**: 24 elements
+
+### Why PLSc fails in bootstrap iterations (Issue #205)
+
+PLSc corrects path coefficients using `solve()` (`feature_consistent.R:73`) which requires the correlation matrix to be non-singular. Bootstrap samples (drawn with replacement) can produce degenerate correlation matrices, especially with HOC models where dimensionality is higher. This is expected behavior — the existing error handling (tryCatch + NA vector + exclusion) is the correct approach, but it only works when `length` is correct.
+
+## Relevant Files
+
+| File | Role |
+|------|------|
+| `R/estimate_bootstrap.R:111` | **Bug location**: `length` formula |
+| `R/estimate_bootstrap.R:114-142` | Bootstrap iteration function with error handler |
+| `R/estimate_bootstrap.R:254` | HTMT dimensions used correctly in reconstruction |
+| `R/evaluate_validity.R:47-80` | HTMT function with HOC-aware construct selection |
+| `R/estimate_pls.R:140-195` | HOC two-stage estimation in estimate_pls |
+| `R/feature_higher_order.R:33-79` | `prepare_higher_order_model()` |
+| `R/feature_higher_order.R:105-153` | `combine_first_order_second_order_matrices()` |
+| `R/feature_consistent.R:48-105` | PLSc implementation (`solve()` failure point) |
+| `R/feature_consistent.R:108-119` | `model_consistent()` triggers PLSc for mode "C" |
+| `tests/testthat/test-hoc.R` | Existing HOC tests (no bootstrap tests) |
+| `tests/testthat/test-bootstrap.R` | Existing bootstrap tests (no HOC tests) |
+
+## Test Plan
+
+### Automated tests (new test file: `tests/testthat/test-hoc-bootstrap.R`)
+
+1. **HOC composite + reflective + bootstrap (PLSc)**: Bootstrap a model with `higher_composite()` and at least one `reflective()` construct. This triggers PLSc, causing some bootstrap iterations to fail, which exercises the `boot_vec_len`-dependent error recovery. This is the core reproduction of issues #299 and #205.
+
+2. **Verify summary() works on bootstrapped HOC model**: Ensure downstream reporting functions handle the expanded dimensions correctly.
+
+## Implementation Steps
+
+- [x] **Step 1: Write failing tests**
+  Created `tests/testthat/test-hoc-bootstrap.R` with the PLSc reproduction test and summary integration check. Dropped HOC composite-only and all-reflective tests (redundant coverage).
+
+- [x] **Step 2: Fix the `length` calculation and rename the variable**
+  Replaced incorrect formula in `R/estimate_bootstrap.R` with computation based on actual matrix dimensions. Renamed variable from `length` to `boot_vec_len` to avoid shadowing R's built-in `length()`.
+
+- [x] **Step 3: Verify HTMT and total_effects are exported/available in parallel workers**
+  Confirmed: `boot_vec_len` is computed on the main process before the cluster starts, so no export issue.
+
+- [x] **Step 4: Run tests and verify**
+  All 47 tests pass across test-hoc-bootstrap, test-bootstrap, and test-hoc.
+
+- [x] **Step 5: Run full test suite**
+  `devtools::test()`: 259 passed, 0 failed, 2 skipped (pre-existing empty plot test files).
+
+## Open Questions / Risks
+
+1. **Non-HOC models with interactions**: The `length` formula is also wrong for interaction models (HTMT excludes interaction constructs), but this only matters if bootstrap iterations fail. For all-composite models with interactions, PLSc isn't triggered and iterations rarely fail, so the bug is latent. The fix will correct this case too.
+
+2. **Performance of computing HTMT before bootstrap loop**: Computing `HTMT(seminr_model)` is cheap (correlation-based, no estimation), so the overhead is negligible.
+
+3. **Bootstrap iteration failure rate**: With PLSc + HOC, many bootstrap iterations may fail. The existing warning message (line 152) reports the count. If failure rates are very high (e.g., >50%), the bootstrap results may not be meaningful. This is a pre-existing concern and out of scope for this fix, but worth noting.
+
+4. **`higher_reflective()` + bootstrap**: The `higher_reflective()` function creates a reflective HOC (mode "C" directly on the HOC construct). Need to verify this scenario works correctly after the fix — the HTMT dimensions may differ again from the composite HOC case.

--- a/R/estimate_bootstrap.R
+++ b/R/estimate_bootstrap.R
@@ -107,11 +107,17 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
                                                "stopCriterion",
                                                "missing"), envir=environment())
 
-      # Calculate the expected nrow of the bootmatrix
-      length <- 3*nrow(seminr_model$path_coef)^2 + 2*nrow(seminr_model$outer_loadings)*ncol(seminr_model$outer_loadings)
+      # Compute actual dimensions for error-recovery NA vector
+      HTMT_matrix <- HTMT(seminr_model)
+      total_matrix <- total_effects(seminr_model$path_coef)
+      boot_vec_len <- length(seminr_model$path_coef) +
+                      length(seminr_model$outer_loadings) +
+                      length(seminr_model$outer_weights) +
+                      length(HTMT_matrix) +
+                      length(total_matrix)
 
       # Function to get PLS estimate results
-      getEstimateResults <- function(i, d = d, length) {
+      getEstimateResults <- function(i, d = d, boot_vec_len) {
         set.seed(seed + i)
         # plsc-bootstrap
         tryCatch({
@@ -131,18 +137,18 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
           error = function(cond) {
             message("Bootstrapping encountered an ERROR: ")
             message(cond)
-            return(rep(NA, length))
+            return(rep(NA, boot_vec_len))
           },
           warning = function(cond) {
             message("Bootstrapping encountered an ERROR: ")
             message(cond)
-            return(rep(NA, length))
+            return(rep(NA, boot_vec_len))
           }
         )
       }
 
       # Bootstrap the estimates
-      utils::capture.output(bootmatrix <- parallel::parSapply(cl, 1:nboot, getEstimateResults, d, length))
+      utils::capture.output(bootmatrix <- parallel::parSapply(cl, 1:nboot, getEstimateResults, d, boot_vec_len))
 
       # Clean the NAs and report the NAs
       bootmatrix <- bootmatrix[,!is.na(bootmatrix[1,])]
@@ -250,9 +256,6 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
       # Assign column names to weights matrix
       colnames(weights_descriptives) <- col_names2
 
-      # Collect HTMT matrix
-      HTMT_matrix <- HTMT(seminr_model)
-
         # Identify start and end points for HTMT data
         start <- end+1
         end <- start+(ncol(HTMT_matrix)*nrow(HTMT_matrix))-1
@@ -279,7 +282,6 @@ bootstrap_model <- function(seminr_model, nboot = 500, cores = NULL, seed = NULL
       colnames(HTMT_descriptives) <- col_names3
 
       # Subset total paths matrix (take care to not be stranded with a single column/row vector)
-      total_matrix <- total_effects(seminr_model$path_coef)
       start <- end+1
       end <- start+(path_cols*path_rows)-1
 

--- a/tests/testthat/test-hoc-bootstrap.R
+++ b/tests/testthat/test-hoc-bootstrap.R
@@ -1,0 +1,46 @@
+# HOC + Bootstrap tests — skipped on CRAN (bootstrap runs are too slow)
+# Reproduces issues #299 and #205: bootstrap_model() errors with PLSc and HOC
+skip_on_cran()
+
+# ── HOC composite + reflective + bootstrap (PLSc) ───────────────────────────
+# Uses a small dataset (50 rows) to force some PLSc iterations to fail,
+# exercising the error-recovery code path where the length bug manifests.
+# This is the core reproduction of issues #299 and #205.
+context("SEMinR bootstraps HOC composite model with PLSc (#299, #205)\n")
+
+set.seed(42)
+small_mobi <- mobi[sample(nrow(mobi), 50), ]
+
+mobi_mm_hoc_plsc <- constructs(
+  reflective("Image",        multi_items("IMAG", 1:5)),
+  reflective("Expectation",  multi_items("CUEX", 1:3)),
+  composite("Quality",       multi_items("PERQ", 1:7)),
+  composite("Value",         multi_items("PERV", 1:2)),
+  higher_composite("Satisfaction", dimensions = c("Image", "Value"),
+                   method = two_stage, weights = mode_A),
+  composite("Complaints",    single_item("CUSCO")),
+  composite("Loyalty",       multi_items("CUSL", 1:3))
+)
+
+mobi_sm_hoc_plsc <- relationships(
+  paths(from = c("Expectation", "Quality"), to = "Satisfaction"),
+  paths(from = "Satisfaction", to = c("Complaints", "Loyalty"))
+)
+
+pls_hoc_plsc <- estimate_pls(data = small_mobi,
+                             measurement_model = mobi_mm_hoc_plsc,
+                             structural_model = mobi_sm_hoc_plsc)
+
+test_that("bootstrap_model() succeeds with HOC composite + PLSc (#299, #205)", {
+  boot_hoc_plsc <- bootstrap_model(pls_hoc_plsc, nboot = 100, cores = 2, seed = 42)
+
+  expect_s3_class(boot_hoc_plsc, "boot_seminr_model")
+  expect_equal(dim(boot_hoc_plsc$boot_paths)[1:2], dim(pls_hoc_plsc$path_coef))
+  expect_equal(dim(boot_hoc_plsc$boot_loadings)[1:2], dim(pls_hoc_plsc$outer_loadings))
+  expect_equal(dim(boot_hoc_plsc$boot_weights)[1:2], dim(pls_hoc_plsc$outer_weights))
+})
+
+test_that("summary() works on bootstrapped HOC + PLSc model", {
+  boot_hoc_plsc <- bootstrap_model(pls_hoc_plsc, nboot = 100, cores = 2, seed = 42)
+  expect_no_error(summary(boot_hoc_plsc))
+})


### PR DESCRIPTION
## Summary

Fixes `bootstrap_model()` crashing when the model contains both Higher-Order Constructs (HOC) and reflective constructs (triggering PLSc). The root cause was a miscalculated vector length in the bootstrap error-recovery code. Closes #299 and #205.

## Plan

- [x] Write failing regression test for HOC + PLSc bootstrap
- [x] Fix `boot_vec_len` calculation using actual matrix dimensions
- [x] Rename shadowed `length` variable to `boot_vec_len`
- [x] Reuse HTMT and total_effects computed at top of function
- [x] Run targeted and full test suites (259 pass, 0 fail)

## Changes

**Bootstrap error recovery** (`R/estimate_bootstrap.R`):
- Replace incorrect formula `3*nrow(path)^2 + 2*nrow(load)*ncol(load)` with sum of actual component sizes
- Compute `HTMT()` and `total_effects()` once at function top, reuse later (minor optimization)
- Rename `length` → `boot_vec_len` to avoid shadowing R's built-in

**Regression tests** (`tests/testthat/test-hoc-bootstrap.R`):
- HOC composite + reflective + PLSc bootstrap (core reproduction of #299/#205)
- `summary()` on bootstrapped HOC + PLSc model

### Design note

The bug only manifests when a bootstrap iteration fails (common with PLSc + HOC due to singular correlation matrices from resampling). The error handler creates an NA vector whose length must match successful iterations — the old formula assumed HTMT has the same dimensions as `path_coef`, which is wrong when HOC constructs alter the HTMT matrix size.