### PR TITLE
fix: cbsem summary reports path directions as IV -> DV

### DIFF
--- a/PLAN.fix-cbsem-summary-path-direction.md
+++ b/PLAN.fix-cbsem-summary-path-direction.md
@@ -1,0 +1,72 @@
+# Fix CBSEM summary path direction (Issue #404)
+
+> **IMPORTANT**: This plan must be kept up-to-date at all times. Assume context can be cleared at any time — this file is the single source of truth for the current state of this work. Update this plan before and after task and subtask implementations.
+
+## Branch
+
+`fix/cbsem-summary-path-direction`
+
+## Goal
+
+Fix `summary.cbsem_model` so structural path significance row names read `IV -> DV` (i.e., `rhs -> lhs`) instead of the current reversed `DV -> IV` (`lhs -> rhs`), consistent with PLS summary and causal arrow convention.
+
+## Strategy: Vertical Slice
+
+Single-file fix with focused test coverage:
+
+1. **Test** — Write failing test that asserts path row names follow `IV -> DV` format (red)
+2. **Fix** — Swap `lhs`/`rhs` in row name construction at line 84 of `R/report_lavaan.R` (green)
+3. **Verify** — Run full CBSEM test suite to confirm no regressions
+
+## Current State
+
+- [x] Plan created
+- [ ] Investigation complete
+- [ ] Tests written
+- [ ] Fix implemented
+- [ ] Verification passed
+
+## Key Findings
+
+- **Root cause**: `R/report_lavaan.R` line 84 — `paste(lhs, "->", rhs)`. In lavaan's `~` operator, `lhs` is the DV (outcome) and `rhs` is the IV (predictor). So the current code produces `DV -> IV`.
+- **Fix location**: `summarize_cb_structure()` in `R/report_lavaan.R`, line 84 only.
+- **Measurement model unaffected**: Line 21 uses `paste(lhs, "->", rhs)` for the `=~` operator, where `lhs` is the construct and `rhs` is the indicator — `Construct -> Indicator` is the correct convention.
+- **Path coefficients matrix**: The `path_matrix` (lines 71-76) already correctly uses `rhs` for row names (antecedents) and `lhs` for column names (outcomes) via `df_xtab_matrix`. Only the `significance` row names are wrong.
+- **Existing tests**: `test-summary-cbsem.R` checks summary tree structure but not row name content.
+- **Model used in tests**: ECSI mobi model with paths like `Image -> Value`, `Quality -> Satisfaction`, etc.
+
+## Questions
+
+> Questions must be crossed off when resolved. Note the decision made.
+
+(none)
+
+## Scope
+
+**In scope**:
+
+- Fix row name direction in `summarize_cb_structure()` significance table
+- Add test asserting correct path direction in CBSEM summary
+
+**Out of scope**:
+
+- Measurement model row names (line 21) — `Construct -> Indicator` is correct for `=~`
+- PLS summary (already correct)
+- Any other summary formatting changes
+
+## Tasks
+
+> **Test-first**: Write or update tests that fail (red) before writing the implementation to make them pass (green).
+
+- [ ] 1a. Add test to `test-summary-cbsem.R` that checks structural path significance row names follow `IV -> DV` format (e.g., `"Image -> Value"` not `"Value -> Image"`)
+- [ ] 2. Fix line 84 in `R/report_lavaan.R`: change `paste(lhs, "->", rhs)` to `paste(rhs, "->", lhs)`
+- [ ] 3. Run `testthat::test_file("tests/testthat/test-summary-cbsem.R")` — confirm new test passes
+- [ ] 4. Run full test suite `devtools::test()` — confirm no regressions
+
+## Completed
+
+(none yet)
+
+---
+
+Last updated: 2026-03-20

--- a/PLAN.fix-cbsem-summary-path-direction.md
+++ b/PLAN.fix-cbsem-summary-path-direction.md
@@ -21,10 +21,10 @@ Single-file fix with focused test coverage:
 ## Current State
 
 - [x] Plan created
-- [ ] Investigation complete
-- [ ] Tests written
-- [ ] Fix implemented
-- [ ] Verification passed
+- [x] Investigation complete
+- [x] Tests written
+- [x] Fix implemented
+- [x] Verification passed — 305 tests pass, 0 failures
 
 ## Key Findings
 
@@ -58,14 +58,12 @@ Single-file fix with focused test coverage:
 
 > **Test-first**: Write or update tests that fail (red) before writing the implementation to make them pass (green).
 
-- [ ] 1a. Add test to `test-summary-cbsem.R` that checks structural path significance row names follow `IV -> DV` format (e.g., `"Image -> Value"` not `"Value -> Image"`)
-- [ ] 2. Fix line 84 in `R/report_lavaan.R`: change `paste(lhs, "->", rhs)` to `paste(rhs, "->", lhs)`
-- [ ] 3. Run `testthat::test_file("tests/testthat/test-summary-cbsem.R")` — confirm new test passes
-- [ ] 4. Run full test suite `devtools::test()` — confirm no regressions
-
 ## Completed
 
-(none yet)
+- [x] 1a. Add test to `test-summary-cbsem.R` that checks structural path significance row names follow `IV -> DV` format
+- [x] 2. Fix line 84 in `R/report_lavaan.R`: change `paste(lhs, "->", rhs)` to `paste(rhs, "->", lhs)`
+- [x] 3. CBSEM summary tests pass (8/8)
+- [x] 4. Full test suite passes (305 tests, 0 failures)
 
 ---
 

--- a/R/report_lavaan.R
+++ b/R/report_lavaan.R
@@ -81,7 +81,7 @@ summarize_cb_structure <- function(object, alpha=0.05) {
     data.frame(est.std, se, z, pvalue, ci.lower, ci.upper)
   )
 
-  rownames(significance) <- with(path_df, paste(lhs, "->", rhs))
+  rownames(significance) <- with(path_df, paste(rhs, "->", lhs))
   colnames(significance) <- c(
     "Std Estimate", "SE", "z-Value", "p-Value",
     paste(alpha_text, "% CI", sep = ""),

--- a/tests/testthat/test-summary-cbsem.R
+++ b/tests/testthat/test-summary-cbsem.R
@@ -62,6 +62,16 @@ test_that("Summary of CBSEM has proper structure", {
                traverse_names(cbsem_summary_tree))
 })
 
+test_that("CBSEM summary path significance row names show IV -> DV direction", {
+  path_names <- rownames(cbsem_summary$paths$significance)
+  # Paths defined as: from = c("Image", "Quality") to = c("Value", "Satisfaction")
+  # Row names should read antecedent -> outcome, not outcome -> antecedent
+  expect_true(any(grepl("^Image ->", path_names)))
+  expect_true(any(grepl("^Quality ->", path_names)))
+  expect_false(any(grepl("^Value -> Image", path_names)))
+  expect_false(any(grepl("^Satisfaction -> Image", path_names)))
+})
+
 
 # CFA Summary
 #seminr syntax for creating measurement model


### PR DESCRIPTION
## Summary

Fix `summary.cbsem_model` so structural path significance row names read `IV -> DV` instead of the reversed `DV -> IV`, consistent with PLS summary and causal arrow convention. Closes #404.

## Plan

- [x] Add test asserting correct `IV -> DV` path direction in CBSEM summary significance row names
- [x] Fix `summarize_cb_structure()` in `R/report_lavaan.R` — swap `lhs`/`rhs` in row name construction
- [x] Run CBSEM summary tests — confirm new test passes (8/8)
- [x] Full regression test suite — confirm no regressions (305 tests, 0 failures)

## Changes

**Report** — `R/report_lavaan.R:84`: swapped `paste(lhs, "->", rhs)` to `paste(rhs, "->", lhs)` in `summarize_cb_structure()`. In lavaan's `~` operator, `lhs` is the DV and `rhs` is the IV, so the old code reversed the direction.

### Design note

Only the structural path significance row names (`~` operator) needed fixing. The measurement model row names (`=~` operator, line 21) correctly show `Construct -> Indicator`.

## Test plan

- [x] New test: CBSEM path significance row names assert `IV -> DV` format (4 assertions)
- [x] Full suite: 305 tests, 0 failures