### PR TITLE
fix: construct_items and all_LOC_items return vector, not matrix (#364)

### DIFF
--- a/R/helpers-mmMatrix.R
+++ b/R/helpers-mmMatrix.R
@@ -46,7 +46,7 @@ construct_items.construct <- function(x, ...) {
 #' @export
 construct_items.measurement_model <- function(x, ...) {
   constructs_only <- all_non_interactions(x)
-  sapply(constructs_only, FUN=construct_items) -> .
+  lapply(constructs_only, FUN=construct_items) -> .
   unlist(., use.names = FALSE) -> .
   unique(.)
 }
@@ -55,7 +55,7 @@ construct_items.measurement_model <- function(x, ...) {
 #' @export
 construct_items.list <- function(x, ...) {
   constructs_only <- all_non_interactions(x)
-  sapply(constructs_only, FUN=construct_items) -> .
+  lapply(constructs_only, FUN=construct_items) -> .
   unlist(., use.names = FALSE) -> .
   unique(.)
 }
@@ -184,7 +184,7 @@ mmMatrix_for_items <- function(mmMatrix, items) {
 all_LOC_items <- function(measurement_model) {
   all_LOCs_only <- all_LOCs(measurement_model)
   constructs_only <- all_non_interactions(all_LOCs_only)
-  sapply(constructs_only, FUN=construct_items) -> .
+  lapply(constructs_only, FUN=construct_items) -> .
   unlist(., use.names = FALSE) -> .
   unique(.)
 }

--- a/tests/testthat/test-equal-item-count.R
+++ b/tests/testthat/test-equal-item-count.R
@@ -1,0 +1,26 @@
+context("Equal item count constructs (#364)\n")
+
+# Fixture: all four constructs have exactly 4 items each.
+# This triggers sapply's matrix simplification in construct_items and all_LOC_items.
+mm_equal <- constructs(
+  composite("TI",     multi_items("TI_", 2:5)),
+  composite("RF",     multi_items("RF_", 1:4)),
+  composite("IA",     multi_items("IA_", 1:4)),
+  composite("EFFECT", multi_items("EFFNESS_", 1:4))
+)
+
+# --- construct_items on measurement_model returns vector, not matrix ---
+test_that("construct_items returns character vector when all constructs have equal item counts", {
+  result <- construct_items(mm_equal)
+  expect_false(is.matrix(result))
+  expect_type(result, "character")
+  expect_length(result, 16)
+})
+
+# --- all_LOC_items returns vector, not matrix ---
+test_that("all_LOC_items returns character vector when all constructs have equal item counts", {
+  result <- all_LOC_items(mm_equal)
+  expect_false(is.matrix(result))
+  expect_type(result, "character")
+  expect_length(result, 16)
+})

--- a/tests/testthat/test-equal-item-count.R
+++ b/tests/testthat/test-equal-item-count.R
@@ -1,7 +1,7 @@
 context("Equal item count constructs (#364)\n")
 
 # Fixture: all four constructs have exactly 4 items each.
-# This triggers sapply's matrix simplification in construct_items and all_LOC_items.
+# Equal item counts ensure construct_items() and all_LOC_items() return a vector, not a matrix.
 mm_equal <- constructs(
   composite("TI",     multi_items("TI_", 2:5)),
   composite("RF",     multi_items("RF_", 1:4)),


### PR DESCRIPTION
## Summary

Fixes #364. `sapply()` returns a matrix instead of a list when all constructs have equal item counts. Since `unlist()` is a no-op on matrices (already atomic), the matrix propagates through to callers like `estimate_pls()`, causing errors with strict data containers (e.g., tibbles).

## Plan

- [x] Failing tests for `construct_items()` and `all_LOC_items()` return type
- [x] Replace `sapply` with `lapply` in three affected functions
- [x] Full test suite passes (313 tests, 0 failures)

## Changes

**Helpers** (`R/helpers-mmMatrix.R`) — `sapply` → `lapply` in:
- `construct_items.measurement_model()`
- `construct_items.list()`
- `all_LOC_items()`

## Test plan

- [x] Unit tests: 2 new tests assert return type is character vector, not matrix
- [x] Full suite: 313 tests, 0 failures