### PR TITLE
fix: 0.70 reliability threshold in plot, and working CRAN maintainer address

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -4,7 +4,7 @@ Title: Building and Estimating Structural Equation Models
 Version: 2.5.0.9000
 Date: 2026-05-21
 Authors@R: c(person("Soumya", "Ray", email = "soumya.ray@gmail.com", role = c("aut", "ths")),
-             person("Nicholas Patrick", "Danks", email = "nicholasdanks@hotmail.com", role = c("aut","cre")),
+             person("Nicholas Patrick", "Danks", email = "seminrgroup@gmail.com", role = c("aut","cre")),
              person("André", "Calero Valdez", role = "aut", email = "andrecalerovaldez@gmail.com"),
              person("Juan Manuel Velasquez", "Estrada", role = "ctb"),
              person("James", "Uanhoro", role = "ctb", email = "James.uanhoro@gmail.com"),

--- a/R/plot_results.R
+++ b/R/plot_results.R
@@ -17,6 +17,15 @@ plot_scores <- function(seminr_model, constructs=NULL) {
 #' @param x A \code{reliability_table} object from a SEMinR PLS model. This can be accessed
 #'   as the \code{reliability} element of the PLS model summary object.
 #'
+#' @param threshold The reference line drawn across the plot, defaulting to
+#'   \code{0.70}. This is the conventional minimum for internal consistency
+#'   reliability (Hair et al., 2019). Note that it is not the same as the
+#'   \code{0.708} threshold applied to indicator loadings, which derives from
+#'   the criterion that an indicator explain at least 50\% of its own variance
+#'   (0.708^2 approximately 0.50). The metrics shown here -- Cronbach's alpha,
+#'   rhoA and rhoC -- are construct-level reliabilities, to which the loading
+#'   threshold does not apply.
+#'
 #' @param ... All other arguments inherited from \code{plot}.
 #'
 #' @examples
@@ -41,7 +50,7 @@ plot_scores <- function(seminr_model, constructs=NULL) {
 #'plot(summary(mobi_pls)$reliability)
 #'
 #' @export
-plot.reliability_table <- function(x, ...) {
+plot.reliability_table <- function(x, threshold = 0.70, ...) {
   stopifnot(inherits(x, "reliability_table"))
 
   metrics <- cbind(matrix(1:nrow(x),ncol = 1), x)
@@ -76,8 +85,11 @@ plot.reliability_table <- function(x, ...) {
   graphics::segments(unlist(metrics[,1])+0.1, unlist(metrics[, "rhoA"]), unlist(metrics[,1])+0.1, unlist(metrics[, "rhoC"]))
   graphics::points(unlist(metrics[,1])+0.1, unlist(metrics[, "rhoC"]), pch=17)
 
-  # threshhold line
-  graphics::abline(h = 0.708, lty = 2, col = "blue")
+  # Threshold line. 0.70 is the conventional minimum for internal consistency
+  # reliability. It is deliberately NOT 0.708, which is the indicator loading
+  # threshold (0.708^2 ~ 0.50 explained variance) and does not apply to the
+  # construct-level metrics plotted here.
+  graphics::abline(h = threshold, lty = 2, col = "blue")
 
   # rotated axis labels: https://www.tenderisthebyte.com/blog/2019/04/25/rotating-axis-labels-in-r/
   graphics::axis(side = 1, labels = FALSE)

--- a/man/plot.reliability_table.Rd
+++ b/man/plot.reliability_table.Rd
@@ -4,11 +4,20 @@
 \alias{plot.reliability_table}
 \title{Function for plotting the measurement model reliability metrics of a PLS model}
 \usage{
-\method{plot}{reliability_table}(x, ...)
+\method{plot}{reliability_table}(x, threshold = 0.7, ...)
 }
 \arguments{
 \item{x}{A \code{reliability_table} object from a SEMinR PLS model. This can be accessed
 as the \code{reliability} element of the PLS model summary object.}
+
+\item{threshold}{The reference line drawn across the plot, defaulting to
+\code{0.70}. This is the conventional minimum for internal consistency
+reliability (Hair et al., 2019). Note that it is not the same as the
+\code{0.708} threshold applied to indicator loadings, which derives from
+the criterion that an indicator explain at least 50\% of its own variance
+(0.708^2 approximately 0.50). The metrics shown here -- Cronbach's alpha,
+rhoA and rhoC -- are construct-level reliabilities, to which the loading
+threshold does not apply.}
 
 \item{...}{All other arguments inherited from \code{plot}.}
 }

--- a/man/seminr-package.Rd
+++ b/man/seminr-package.Rd
@@ -17,7 +17,7 @@ Useful links:
 
 }
 \author{
-\strong{Maintainer}: Nicholas Patrick Danks \email{nicholasdanks@hotmail.com}
+\strong{Maintainer}: Nicholas Patrick Danks \email{seminrgroup@gmail.com}
 
 Authors:
 \itemize{

--- a/tests/testthat/test-plot-reliability.R
+++ b/tests/testthat/test-plot-reliability.R
@@ -1,0 +1,41 @@
+# Regression test for the reliability plot threshold.
+#
+# plot.reliability_table() previously drew its reference line at 0.708, which is
+# the indicator LOADING threshold (0.708^2 ~ 0.50 explained variance). The
+# metrics this plot shows -- Cronbach's alpha, rhoA and rhoC -- are
+# construct-level internal consistency reliabilities, judged against 0.70.
+# Reported by Marko Sarstedt.
+
+test_that("the reliability plot threshold defaults to 0.70", {
+  expect_equal(formals(plot.reliability_table)$threshold, 0.70)
+})
+
+test_that("the loading threshold is not hardcoded in the reliability plot", {
+  # Guards against the value being written back into the function body, which is
+  # how the original defect arose. Checking the body rather than the default
+  # catches a hardcoded abline that ignores the argument.
+  body_text <- paste(deparse(body(plot.reliability_table)), collapse = " ")
+  expect_false(grepl("0.708", body_text, fixed = TRUE))
+  expect_true(grepl("h = threshold", body_text, fixed = TRUE))
+})
+
+test_that("the reliability plot accepts a caller-supplied threshold", {
+  mobi_mm <- constructs(
+    composite("Image",        multi_items("IMAG", 1:5)),
+    composite("Expectation",  multi_items("CUEX", 1:3)),
+    composite("Satisfaction", multi_items("CUSA", 1:3))
+  )
+  mobi_sm <- relationships(
+    paths(to = "Satisfaction", from = c("Image", "Expectation"))
+  )
+  model <- estimate_pls(mobi, measurement_model = mobi_mm,
+                        structural_model = mobi_sm)
+  rel <- summary(model)$reliability
+
+  grDevices::pdf(NULL)
+  on.exit(grDevices::dev.off(), add = TRUE)
+
+  expect_silent(plot(rel))
+  expect_silent(plot(rel, threshold = 0.90))
+  expect_invisible(plot(rel))
+})


### PR DESCRIPTION
Closes #421. Refs #420.

Two changes, both needed for the next CRAN release.

---

# 1. Reliability plot threshold (#421)

`plot.reliability_table()` drew its reference line at **0.708**. That is the indicator **loading** threshold, which comes from the criterion that an indicator explain at least 50% of its own variance (0.708² ≈ 0.50). The metrics this plot shows — Cronbach's alpha, rhoA and rhoC — are **construct-level** internal consistency reliabilities, judged against **0.70**.

Reported by Marko Sarstedt while reviewing proofs for the PLS-SEM R book, where figure 4.7 plots construct reliabilities against this line. The book text has already been corrected; the figure comes from this function, so the fix belongs here.

## Change

```diff
-  graphics::abline(h = 0.708, lty = 2, col = "blue")
+  graphics::abline(h = threshold, lty = 2, col = "blue")
```

The value is now exposed as a `threshold` argument defaulting to `0.70`, rather than sitting as a literal in the function body. Two reasons for the argument rather than a bare literal swap:

- the intended value becomes documented and testable instead of buried
- users assessing against a different convention can set their own line

Both the roxygen and an inline comment record why it is 0.70 and not 0.708, since the two thresholds are genuinely easy to confuse.

## Effect on users

Anyone calling `plot(summary(model)$reliability)` has been seeing a line 0.008 too high. The practical impact is on constructs whose reliability falls between 0.700 and 0.708 — drawn as failing when they pass. Existing calls keep working unchanged; only the position of the line moves.

## Tests

New `tests/testthat/test-plot-reliability.R`:

- the default is 0.70
- no literal `0.708` remains in the function body, and the abline reads from the argument — this catches a future edit that hardcodes the value again and ignores the parameter, which is how the original defect arose
- a caller-supplied threshold is accepted

Full suite: **287 passing, 0 failures**.

---

# 2. CRAN maintainer address (#420)

CRAN reported that mail to the maintainer address bounced and asked for a new version carrying a working one. The address moves from `nicholasdanks@hotmail.com` to `seminrgroup@gmail.com` in `DESCRIPTION`, with `man/seminr-package.Rd` regenerated to match.

The `Maintainer` field still derives as a named individual — `Nicholas Patrick Danks <seminrgroup@gmail.com>`. *Writing R Extensions* requires a CRAN maintainer to be a person rather than a mailing list or corporate entity, so only the address changes; the name does not.

The equivalent change is already made in seminrExtras (sem-in-r/seminrExtras#17), which shipped in 1.0.3.

Carried on this branch rather than its own because both changes have to land in the same release, and the address fix is a single line.

## Follow-up

Figure 4.7 needs regenerating for the book proofs once this is released, so it would be good to have this in the next CRAN version.

Not addressed here: whether to also draw the 0.90–0.95 upper bound on the reliability plot. Redundancy above that range is arguably the more common problem in practice than falling below 0.70, but adding a second line changes the plot's appearance for every existing user, so it is a separate decision.
